### PR TITLE
REDCORE-359 Fix missing License tag

### DIFF
--- a/mvcoverride.xml
+++ b/mvcoverride.xml
@@ -4,6 +4,7 @@
 	<author>redCOMPONENT</author>
 	<creationDate>July 2014</creationDate>
 	<copyright>Copyright (C) 2008 - 2015 redCOMPONENT.com. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later, see LICENSE.</license>
 	<authorEmail>email@redcomponent.com</authorEmail>
 	<authorUrl>www.redcomponent.com</authorUrl>
 	<version>1.4.10</version>


### PR DESCRIPTION
Fixes:
![screen shot 2015-04-21 at 12 23 40](https://cloud.githubusercontent.com/assets/1375475/7250197/881574c2-e820-11e4-8e01-704ebaa06234.png)
